### PR TITLE
Provided initial layout for pages of rescue-the-tux event

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,86 +1,29 @@
 # Linux User Club, VIT Chennai
 - Landing page for the club
+  
+# Pages Description
+  
+1. Welcome : Shows the welcome text to the participant. It describes the schedule of the event. And also shows the background story of the competition (the kidnapping thing of Tux by Bill gates. We can add designed videos/images here to make it more interesting.  
+2. Instructions : Shows the instructions to the participants which they need to follow while playing the competition.  
+3. Registration : A normal registration page having name, reg.no, email, contact, payment id stuffs.  
+4. Login : A normal login page whihc has the username and password field and a submit button. Must also have the forgot password option.  
+5. Challenges : Show all the challenges in stages to the participant. Every challenge must be enclosed in a box which pops up when the participant clicks it. Every box should have a input flag field and a submit button, which takes the flag entered by the participants and checks if its correct or not.  
+6. Leaderboard : Make a leaderboard page which shows all the teams participating and their current score. Arrange the teams in descending order. Can add leaderboard graphs if time permits. but basic thing required is showing all teams in descending order.  
+  
+# Contributing Guidelines for Rescue-The-Tux event
+  
+1. Fork this repository into your own copy.
+2. Clone your copy of the repository into your local machine.
+3. Run the command `npm install` in the local repo.  
+4. Run the command `git checkout -b rescue-the-tux origin/rescue-the-tux` to make the local branch track the remote branch.  
+5. Create a unique branch in your local repo. Branch name format: <user_name>-add-<page>. So, if your name is 'Tux', and you are adding the Leaderboard page for the event, then your branch name should be : `Tux-add-Leaderboard`. Ensure that your unique branch is being created from the `rescue-the-tux` branch source, and not the master branch source.
+6. Run the command `npm start` to see how the website looks before you add your changes.  
+7. Go to the respective directory of the page you are wanting to add.  
+    * if you want to add challenges page, go to `src/pages/rescueTheTux/challenges`.
+    * similarly if you want to add leaderboard page, registration page or login page etc. go to `src/pages/rescueTheTux/leaderboard`, `src/pages/rescueTheTux/registration`, `src/pages/rescueTheTux/login` directories.  
+8. Make your changes in the respective directory. You can add as many files as you want in your directory to make your page. Please do not make any changes in other directories. If you want to work on mulitple pages, open multiple Pull Requests. But in a single PR, just deal with the respective page directory.  
+9. Run the command `npm start` again to see how the website looks after your changes have been added. 
+10. Save and Commit your files in the local repo.
+11. Push your Commits to the remote repo (your copy of the main repo).
+12. Create a Pull Request from your unique branch to the **rescue-the-tux** branch of our main repo.
 
-# TODO
-- [x] active navlink should be set according to the current URL
-- [ ] proper responsive design for the top bar (idk what to do)
-- [ ] footer (should go below the dock(kinda merge into it) for small screens)
-- [ ] header (a proper display of LUG's name in the header (above the topBar or in it, idk)
-
-# Guidelines:
-- push major changes through a separate branch (or fork)
-- be a bit descriptive in commits
-- branching
-    - branch naming format: add-<feature-name>
-    - we still need to figure out a system to prune uneeded branches after merging
-
-# Getting Started with Create React App
-
-This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).
-
-## Available Scripts
-
-In the project directory, you can run:
-
-### `npm start`
-
-Runs the app in the development mode.\
-Open [http://localhost:3000](http://localhost:3000) to view it in your browser.
-
-The page will reload when you make changes.\
-You may also see any lint errors in the console.
-
-### `npm test`
-
-Launches the test runner in the interactive watch mode.\
-See the section about [running tests](https://facebook.github.io/create-react-app/docs/running-tests) for more information.
-
-### `npm run build`
-
-Builds the app for production to the `build` folder.\
-It correctly bundles React in production mode and optimizes the build for the best performance.
-
-The build is minified and the filenames include the hashes.\
-Your app is ready to be deployed!
-
-See the section about [deployment](https://facebook.github.io/create-react-app/docs/deployment) for more information.
-
-### `npm run eject`
-
-**Note: this is a one-way operation. Once you `eject`, you can't go back!**
-
-If you aren't satisfied with the build tool and configuration choices, you can `eject` at any time. This command will remove the single build dependency from your project.
-
-Instead, it will copy all the configuration files and the transitive dependencies (webpack, Babel, ESLint, etc) right into your project so you have full control over them. All of the commands except `eject` will still work, but they will point to the copied scripts so you can tweak them. At this point you're on your own.
-
-You don't have to ever use `eject`. The curated feature set is suitable for small and middle deployments, and you shouldn't feel obligated to use this feature. However we understand that this tool wouldn't be useful if you couldn't customize it when you are ready for it.
-
-## Learn More
-
-You can learn more in the [Create React App documentation](https://facebook.github.io/create-react-app/docs/getting-started).
-
-To learn React, check out the [React documentation](https://reactjs.org/).
-
-### Code Splitting
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/code-splitting](https://facebook.github.io/create-react-app/docs/code-splitting)
-
-### Analyzing the Bundle Size
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size](https://facebook.github.io/create-react-app/docs/analyzing-the-bundle-size)
-
-### Making a Progressive Web App
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app](https://facebook.github.io/create-react-app/docs/making-a-progressive-web-app)
-
-### Advanced Configuration
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/advanced-configuration](https://facebook.github.io/create-react-app/docs/advanced-configuration)
-
-### Deployment
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/deployment](https://facebook.github.io/create-react-app/docs/deployment)
-
-### `npm run build` fails to minify
-
-This section has moved here: [https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify](https://facebook.github.io/create-react-app/docs/troubleshooting#npm-run-build-fails-to-minify)

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ import Home from './pages/home';
 import Events from './pages/events/events';
 import LearnLinux from './pages/learnLinux/learnLinux';
 // import UserForm from './pages/recruitment_2022/recruitment';
+import RescueTheTux from './pages/rescueTheTux/home';
 
 const pages = [
     {
@@ -27,6 +28,11 @@ const pages = [
         title: 'Learn Linux',
         link: '/learn-linux',
         component: <LearnLinux />
+    },
+    {
+	title: 'Rescue the Tux',
+	link: '/rescue-the-tux',
+	component: <RescueTheTux />
     }
     //, {
     //     title: 'Recruitment 2022',

--- a/src/pages/rescueTheTux/challenges/index.js
+++ b/src/pages/rescueTheTux/challenges/index.js
@@ -1,0 +1,16 @@
+// Edit this file to write your code
+// which shows all the challenges
+// in a floating-box format.
+
+export default function Challenges() {
+	
+	return (
+		<>
+		<h1> Challenges </h1>
+		Put the list of all accepted challenges here
+		in floating-boxes type format. For ex, see
+		how picoCTF displays their challenges to 
+		the user. https://play.picoctf.org/practice
+		</>
+	);
+}

--- a/src/pages/rescueTheTux/home.js
+++ b/src/pages/rescueTheTux/home.js
@@ -1,0 +1,33 @@
+import TerminalWindow from '../../components/terminal/terminalWindow';
+import WelcomeText from './welcome';
+import Instructions from './instructions';
+import Challenges from './challenges';
+import Leaderboard from './leaderboard';
+import Registration from './registration';
+import Login from './login';
+
+export default function RTTEvent () {
+	return (
+		<>
+		<TerminalWindow
+		title='Rescue the Tux'
+		prompts = {[
+			{ path: '~', command: 'cd rescue-the-tux' },
+			{ 
+				path: '~/rescue-the-tux',
+				command: './rescue-the-tux --play'
+			}
+		]}
+		>
+		
+		<WelcomeText />
+		<Instructions />
+		<Registration />
+		<Login />
+		<Challenges />
+		<Leaderboard />
+
+		</TerminalWindow>
+		</>
+	);
+}

--- a/src/pages/rescueTheTux/instructions/index.js
+++ b/src/pages/rescueTheTux/instructions/index.js
@@ -1,0 +1,18 @@
+export default function Instructions() {
+	// Just writing random stuff here.
+	// Update the list giving instructions
+	// about the event and how to play the
+	// linux CTF.
+	return (
+		<>
+		<h1> Instructions </h1>
+		1. Be ethical
+		<br />
+		2. Think out of the box
+		<br />
+		3. Have fun
+		<br />
+		</>
+	);
+}
+		

--- a/src/pages/rescueTheTux/leaderboard/index.js
+++ b/src/pages/rescueTheTux/leaderboard/index.js
@@ -1,0 +1,17 @@
+// Edit this file to write your code
+// which adds a leaderboard page
+// showing all the teams in the 
+// competition, with their current
+// progress.
+
+export default function Leaderboard() {
+	return (
+		<>
+		<h1> User Leaderboard </h1>
+		Shows the list of all teams
+		in the order of highest to lowest
+		points. Each team gets points by
+		clearing a stage in the game.
+		</>
+	);
+}

--- a/src/pages/rescueTheTux/login/index.js
+++ b/src/pages/rescueTheTux/login/index.js
@@ -1,0 +1,16 @@
+// Edit this file to write your code
+// which adds a login page for the 
+// participant to login to the 
+// competition on the event day
+
+export default function Login() {
+	return (
+		<>
+		<h1> Login Page </h1>
+		Just a login page which has options
+		of username and password fields,
+		with a submit button. Also, should have
+		the option of forgot password.
+		</>
+	);
+}

--- a/src/pages/rescueTheTux/registration/index.js
+++ b/src/pages/rescueTheTux/registration/index.js
@@ -1,0 +1,15 @@
+// Edit this file to write your code
+// which adds a registration page
+// needed to add a new participant to the event.
+
+export default function Challenges() {
+	
+	return (
+		<>
+		<h1> Register here </h1>
+		Just a registration form containing fields
+		like name, reg.no., email, whatsapp no.,
+		payment id, meal pref: veg/nveg.
+		</>
+	);
+}

--- a/src/pages/rescueTheTux/welcome/index.js
+++ b/src/pages/rescueTheTux/welcome/index.js
@@ -1,0 +1,20 @@
+export default function WelcomeText() {
+	// Write an innovative welcome message
+	// for the event. The message should
+	// describe the event and show the 
+	// scenario of Tux Capture.
+
+	return (
+		<>
+		<h1> Welcome Participant </h1>
+		Oh no, Bill Gates has kidnapped our lovely Tux. His mission is to bring Apocalypse 
+		to the Technical World by wiping out the existence of Tux and thus, blowing away 
+		all the services which run upon the Linux kernel. This means the end to Google, 
+		Meta, Twitter and ... the internet?
+		<br />
+		We have to hurry, we have to rescue the Tux. Are you joining the team? Our lovely 
+		Tux has also left some clues on his way diving into the linux kernel. Start with 
+		Challenge 1.
+		</>
+	);
+}


### PR DESCRIPTION
Added the layout for the required pages of the rescue-the-tux event. Members of the club can work on the individual directories like `src/pages/rescueTheTux/challenges`, `src/pages/rescueTheTux/leaderboard`, `src/pages/rescueTheTux/registration` etc. This layout should prevent merge conflicts in the future when members are submitting their individual PRs.