### PR TITLE
Fixed link issue in dock

### DIFF
--- a/src/components/lugLink/lugLink.js
+++ b/src/components/lugLink/lugLink.js
@@ -6,8 +6,11 @@ export default function LugLink({ link, children }) {
         <Link
             className={lugLinkStyles.index}
             to={link}
-            target='_blank'
             rel='noopener noreferrer'
+            onClick={(e)=>{
+                e.preventDefault();
+                window.open(link,'_blank')
+            }}
         >
             {children}
         </Link>


### PR DESCRIPTION
I have fixed the issue with routing external URLs of our social media handles on the website.
Previously, the external URL was getting appended to the existing URL, making the link inaccessible. 

Here's the screenshot of the problem:
<img width="441" alt="image" src="https://user-images.githubusercontent.com/92030666/235707257-dd83cde0-89e5-44b1-9fe2-fcdb9e6bba29.png">

I have fixed it with the help of the onClick event handler. 

Here's the screenshot after the fix:
<img width="449" alt="image" src="https://user-images.githubusercontent.com/92030666/235707703-edacf124-4c34-400a-9451-a33dd5bca0e3.png">
